### PR TITLE
fix(#63): fix scroll issues on iOS

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -6,17 +6,11 @@
  */
 *{ box-sizing: border-box; }
 
-html, body {
+html {
   padding: 0;
   margin: 0;
   font-family: $fontstack;
   font-size: 4vw;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
-  flex: 1;
   .index {
     color: $textColor;
   }
@@ -26,8 +20,16 @@ html, body {
   }
 }
 
-@media (max-width: $tablet - 1) {
-  body {
+body {
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  flex: 1;
+  @media (max-width: $tablet - 1) {
+    padding-bottom: 15vh;
     flex-direction: column-reverse;
   }
 }
@@ -152,11 +154,14 @@ a.link {
     }
   }
   @media (max-width: $tablet - 1) {
+    position: fixed;
+    left:0; right:0;
+    bottom: 0;
     flex-direction: column-reverse;
     z-index: 9999;
     box-shadow: 0 0 5px #333;
     .nav-bar {
-      padding: 10px
+      padding: 10px 0;
     }
   }
 }


### PR DESCRIPTION
Set menu to fixed to be able to use momentum scrolling as well as the tap to top behavior.
Splitted html / body style to have a working momentum scrolling by default (fixing body and html dimensions mess up scrollable content detection).